### PR TITLE
Fix SMCRadeonGPU on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Kext|Description
 [NVMeFix](https://github.com/acidanthera/NVMeFix/releases)|Used for fixing power management and initialization on non-Apple NVMe.
 [SATA-Unsupported](https://github.com/khronokernel/Legacy-Kexts/blob/master/Injectors/Zip/SATA-unsupported.kext.zip)|Adds support for a large variety of SATA controllers, mainly relevant for laptops which have issues seeing the SATA drive in macOS.<br>We recommend testing without this first.
 [RestrictEvents](https://github.com/acidanthera/RestrictEvents/releases)|Better experience with unsupported processors like AMD, Disable MacPro7,1 memory warnings and provide upgrade to macOS Monterey via Software Updates when available.
-[SMDRadeonGPU](https://github.com/aluveitie/RadeonSensor)|Used for monitoring GPU temperature on AMD GPU systems. Requires RadeonSensor from the same repository. Requires macOS 11 or newer.
+[SMCRadeonGPU](https://github.com/ChefKissInc/RadeonSensor)|Used for monitoring GPU temperature on AMD GPU systems. Requires RadeonSensor from the same repository. Requires macOS 11 or newer.
 
 # ACPI Tables - AMD
 


### PR DESCRIPTION
Whats up Luchina!

During the upgrade, I noticed a typo in the readme and also that the SMCRadeonGPU repository mentioned has been archived by _aluveitie_ and is now maintained by _ChefKissInc_ and the new repository seems to be more up-to-date and functional as in the screenshot.

**RadeonGadget.app with kexts from ChefKissInc**
![Screenshot RadeonGadget](https://github.com/luchina-gabriel/BASE-EFI-AMD-RYZEN-THREADRIPPER/assets/52332643/7b176877-1adf-4af7-9279-93f21fb58a81)

**RadeonGadget.app with kexts from Aluveitie**
![Screenshot RadeonGadget](https://github.com/luchina-gabriel/BASE-EFI-AMD-RYZEN-THREADRIPPER/assets/52332643/c38ffcb1-a086-4be5-9669-20c635911980)



